### PR TITLE
Add additional sensors to the integration.

### DIFF
--- a/custom_components/sutro/api.py
+++ b/custom_components/sutro/api.py
@@ -35,10 +35,19 @@ class SutroApiClient:
                     serialNumber
                     temperature
                     cartridgeCharges
+                    health
+                    coreStatus
+                    lidOpen
+                    online
+                    shouldTakeReadings
+                }
+                hub {
+                    online
                 }
                 pool {
                     latestReading {
                         alkalinity
+                        bromine
                         chlorine
                         ph
                         readingTime

--- a/custom_components/sutro/binary_sensor.py
+++ b/custom_components/sutro/binary_sensor.py
@@ -5,7 +5,6 @@ from homeassistant.components.binary_sensor import DEVICE_CLASS_OPENING
 from homeassistant.components.binary_sensor import DEVICE_CLASS_PROBLEM
 from homeassistant.helpers.entity import EntityCategory
 
-
 from .const import ATTRIBUTION
 from .const import DOMAIN
 from .const import ICON_DEVICE_ONLINE

--- a/custom_components/sutro/binary_sensor.py
+++ b/custom_components/sutro/binary_sensor.py
@@ -1,0 +1,159 @@
+"""Binary sensor platform for integration_blueprint."""
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    DEVICE_CLASS_CONNECTIVITY,
+    DEVICE_CLASS_OPENING,
+    DEVICE_CLASS_PROBLEM,
+)
+
+
+from .const import ATTRIBUTION
+from .const import DOMAIN
+from .const import NAME
+from .const import VERSION
+from .const import ICON_DEVICE_ONLINE
+from .entity import SutroEntity
+
+
+async def async_setup_entry(hass, entry, async_add_devices):
+    """Setup binary_sensor platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_devices(
+        [
+            DeviceOnlineBinarySensor(coordinator, entry),
+            DeviceLidOpenBinarySensor(coordinator, entry),
+            HubOnlineBinarySensor(coordinator, entry),
+            CoreStatusBinarySensor(coordinator, entry),
+            NotTakingReadingsBinarySensor(coordinator, entry),
+        ]
+    )
+
+
+class SutroBinarySensor(SutroEntity, BinarySensorEntity):
+    """sutro Binary Sensor class."""
+
+    @property
+    def device_info(self):
+        """Return the parent device information."""
+        device_unique_id = self.coordinator.data["me"]["device"]["serialNumber"]
+        return {
+            "identifiers": {(DOMAIN, device_unique_id)},
+            "name": NAME,
+            "model": VERSION,
+            "manufacturer": NAME,
+        }
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {
+            "attribution": ATTRIBUTION,
+            "integration": DOMAIN,
+        }
+
+
+class DeviceOnlineBinarySensor(SutroBinarySensor):
+    """Representation of an Device Online Binary Sensor."""
+
+    _attr_name = f"{NAME} Device Online"
+    _attr_icon = ICON_DEVICE_ONLINE
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for the binary sensor."""
+        return f"{self.coordinator.data['me']['device']['serialNumber']}-device-online"
+
+    @property
+    def device_class(self):
+        """Return the class of this binary_sensor."""
+        return DEVICE_CLASS_CONNECTIVITY
+
+    @property
+    def is_on(self):
+        """Return true if the device is connected."""
+        return self.coordinator.data["me"]["device"]["online"]
+
+
+class HubOnlineBinarySensor(SutroBinarySensor):
+    """Representation of an Hub Online Binary Sensor."""
+
+    _attr_name = f"{NAME} Hub Online"
+    _attr_icon = ICON_DEVICE_ONLINE
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for the binary sensor."""
+        return f"{self.coordinator.data['me']['device']['serialNumber']}-hub-online"
+
+    @property
+    def device_class(self):
+        """Return the class of this binary_sensor."""
+        return DEVICE_CLASS_CONNECTIVITY
+
+    @property
+    def is_on(self):
+        """Return true if the device is connected."""
+        return self.coordinator.data["me"]["hub"]["online"]
+
+
+class DeviceLidOpenBinarySensor(SutroBinarySensor):
+    """Representation of an Device Online Binary Sensor."""
+
+    _attr_name = f"{NAME} Device Lid Open"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for the binary sensor."""
+        return f"{self.coordinator.data['me']['device']['serialNumber']}-lid-open"
+
+    @property
+    def device_class(self):
+        """Return the class of this binary_sensor."""
+        return DEVICE_CLASS_OPENING
+
+    @property
+    def is_on(self):
+        """Return true if the binary_sensor is on."""
+        return self.coordinator.data["me"]["device"]["lidOpen"]
+
+
+class CoreStatusBinarySensor(SutroBinarySensor):
+    """Representation of an Hub Online Binary Sensor."""
+
+    _attr_name = f"{NAME} Core Status"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for the binary sensor."""
+        return f"{self.coordinator.data['me']['device']['serialNumber']}-core-status"
+
+    @property
+    def device_class(self):
+        """Return the class of this binary_sensor."""
+        return DEVICE_CLASS_PROBLEM
+
+    @property
+    def is_on(self):
+        """Return true if the device has a problem."""
+        return not self.coordinator.data["me"]["device"]["coreStatus"]
+
+
+class NotTakingReadingsBinarySensor(SutroBinarySensor):
+    """Representation of an Hub Online Binary Sensor."""
+
+    _attr_name = f"{NAME} Taking Readings"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for the binary sensor."""
+        return f"{self.coordinator.data['me']['device']['serialNumber']}-not-taking-readings"
+
+    @property
+    def device_class(self):
+        """Return the class of this binary_sensor."""
+        return DEVICE_CLASS_PROBLEM
+
+    @property
+    def is_on(self):
+        """Return true if the device is fine."""
+        return not self.coordinator.data["me"]["device"]["shouldTakeReadings"]

--- a/custom_components/sutro/binary_sensor.py
+++ b/custom_components/sutro/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Binary sensor platform for integration_blueprint."""
+"""Binary Sensor platform for Sutro."""
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     DEVICE_CLASS_CONNECTIVITY,

--- a/custom_components/sutro/binary_sensor.py
+++ b/custom_components/sutro/binary_sensor.py
@@ -5,6 +5,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_OPENING,
     DEVICE_CLASS_PROBLEM,
 )
+from homeassistant.helpers.entity import EntityCategory
 
 
 from .const import ATTRIBUTION
@@ -57,6 +58,7 @@ class DeviceOnlineBinarySensor(SutroBinarySensor):
 
     _attr_name = f"{NAME} Device Online"
     _attr_icon = ICON_DEVICE_ONLINE
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self):
@@ -79,6 +81,7 @@ class HubOnlineBinarySensor(SutroBinarySensor):
 
     _attr_name = f"{NAME} Hub Online"
     _attr_icon = ICON_DEVICE_ONLINE
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self):
@@ -121,6 +124,7 @@ class CoreStatusBinarySensor(SutroBinarySensor):
     """Representation of an Hub Online Binary Sensor."""
 
     _attr_name = f"{NAME} Core Status"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self):
@@ -142,6 +146,7 @@ class NotTakingReadingsBinarySensor(SutroBinarySensor):
     """Representation of an Hub Online Binary Sensor."""
 
     _attr_name = f"{NAME} Taking Readings"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self):

--- a/custom_components/sutro/binary_sensor.py
+++ b/custom_components/sutro/binary_sensor.py
@@ -1,18 +1,16 @@
 """Binary Sensor platform for Sutro."""
-from homeassistant.components.binary_sensor import (
-    BinarySensorEntity,
-    DEVICE_CLASS_CONNECTIVITY,
-    DEVICE_CLASS_OPENING,
-    DEVICE_CLASS_PROBLEM,
-)
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import DEVICE_CLASS_CONNECTIVITY
+from homeassistant.components.binary_sensor import DEVICE_CLASS_OPENING
+from homeassistant.components.binary_sensor import DEVICE_CLASS_PROBLEM
 from homeassistant.helpers.entity import EntityCategory
 
 
 from .const import ATTRIBUTION
 from .const import DOMAIN
+from .const import ICON_DEVICE_ONLINE
 from .const import NAME
 from .const import VERSION
-from .const import ICON_DEVICE_ONLINE
 from .entity import SutroEntity
 
 

--- a/custom_components/sutro/const.py
+++ b/custom_components/sutro/const.py
@@ -1,5 +1,4 @@
 """Constants for Sutro."""
-
 from homeassistant.const import Platform
 
 # Base component constants

--- a/custom_components/sutro/const.py
+++ b/custom_components/sutro/const.py
@@ -1,4 +1,7 @@
 """Constants for Sutro."""
+
+from homeassistant.const import Platform
+
 # Base component constants
 NAME = "Sutro"
 DOMAIN = "sutro"
@@ -11,14 +14,16 @@ ISSUE_URL = "https://github.com/ydogandjiev/hass-sutro/issues"
 # Icons
 ICON_ACIDITY = "mdi:ph"
 ICON_ALKALINITY = "mdi:test-tube"
+ICON_BROMINE = "mdi:water-percent"
 ICON_CHLORINE = "mdi:water-percent"
 ICON_TEMPERATURE = "mdi:thermometer"
 ICON_BATTERY = "mdi:battery"
 ICON_CHARGES = "mdi:water-outline"
+ICON_DEVICE_ONLINE = "mdi:check-network-outline"
+ICON_HEALTH = "mdi:hospital-box"
 
 # Platforms
-SENSOR = "sensor"
-PLATFORMS = [SENSOR]
+PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR]
 
 # Configuration and options
 CONF_TOKEN = "token"

--- a/custom_components/sutro/sensor.py
+++ b/custom_components/sutro/sensor.py
@@ -14,7 +14,9 @@ from .const import DOMAIN
 from .const import ICON_ACIDITY
 from .const import ICON_ALKALINITY
 from .const import ICON_CHARGES
+from .const import ICON_BROMINE
 from .const import ICON_CHLORINE
+from .const import ICON_HEALTH
 from .const import NAME
 from .const import VERSION
 from .entity import SutroEntity
@@ -33,6 +35,8 @@ async def async_setup_entry(
             TemperatureSensor(coordinator, entry),
             BatterySensor(coordinator, entry),
             CartridgeCharges(coordinator, entry),
+            BromineSensor(coordinator, entry),
+            DeviceHealthSensor(coordinator, entry),
         ]
     )
 
@@ -62,7 +66,19 @@ class SutroSensor(SutroEntity, SensorEntity):
         }
 
 
-class AciditySensor(SutroSensor):
+class SutroDeviceSensor(SutroSensor):
+    """Base class for Sutro Device Sensors."""
+
+    @property
+    def extra_state_attributes(self):
+        return {
+            "reading_time": self.coordinator.data["me"]["pool"]["latestReading"][
+                "readingTime"
+            ]
+        }
+
+
+class AciditySensor(SutroDeviceSensor):
     """Representation of an Acidity Sensor."""
 
     _attr_name = f"{NAME} Acidity Sensor"
@@ -80,7 +96,7 @@ class AciditySensor(SutroSensor):
         return f"{self.coordinator.data['me']['device']['serialNumber']}-acidity"
 
 
-class AlkalinitySensor(SutroSensor):
+class AlkalinitySensor(SutroDeviceSensor):
     """Representation of an Alkalinity Sensor."""
 
     _attr_name = f"{NAME} Alkalinity Sensor"
@@ -98,7 +114,7 @@ class AlkalinitySensor(SutroSensor):
         return f"{self.coordinator.data['me']['device']['serialNumber']}-alkalinity"
 
 
-class FreeChlorineSensor(SutroSensor):
+class FreeChlorineSensor(SutroDeviceSensor):
     """Representation of a Free Chlorine Sensor."""
 
     _attr_name = f"{NAME} Free Chlorine Sensor"
@@ -108,12 +124,36 @@ class FreeChlorineSensor(SutroSensor):
     @property
     def native_value(self):
         """Return the native value of the sensor."""
-        return float(self.coordinator.data["me"]["pool"]["latestReading"]["chlorine"])
+        val = self.coordinator.data["me"]["pool"]["latestReading"]["chlorine"]
+        if val is None:
+            return 0
+        return float(val)
 
     @property
     def unique_id(self):
         """Return a unique ID to use for the sensor."""
         return f"{self.coordinator.data['me']['device']['serialNumber']}-chlorine"
+
+
+class BromineSensor(SutroDeviceSensor):
+    """Representation of a Free Chlorine Sensor."""
+
+    _attr_name = f"{NAME} Bromine Sensor"
+    _attr_icon = ICON_BROMINE
+    _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
+
+    @property
+    def native_value(self):
+        """Return the native value of the sensor."""
+        val = self.coordinator.data["me"]["pool"]["latestReading"]["bromine"]
+        if val is None:
+            return 0
+        return float(val)
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for the sensor."""
+        return f"{self.coordinator.data['me']['device']['serialNumber']}-bromine"
 
 
 class TemperatureSensor(SutroSensor):
@@ -168,3 +208,21 @@ class CartridgeCharges(SutroSensor):
     def unique_id(self):
         """Return a unique ID to use for the sensor."""
         return f"{self.coordinator.data['me']['device']['serialNumber']}-charges"
+
+
+class DeviceHealthSensor(SutroSensor):
+    """Representation of a Device Health Sensor."""
+
+    _attr_state_class = None
+    _attr_name = f"{NAME} Device Health"
+    _attr_icon = ICON_HEALTH
+
+    @property
+    def native_value(self):
+        """Return the native value of the sensor."""
+        return self.coordinator.data["me"]["device"]["health"]
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for the sensor."""
+        return f"{self.coordinator.data['me']['device']['serialNumber']}-health"

--- a/custom_components/sutro/sensor.py
+++ b/custom_components/sutro/sensor.py
@@ -7,7 +7,9 @@ from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION
 from homeassistant.const import PERCENTAGE
 from homeassistant.const import TEMP_FAHRENHEIT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
 
 from .const import ATTRIBUTION
 from .const import DOMAIN
@@ -216,6 +218,7 @@ class DeviceHealthSensor(SutroSensor):
     _attr_state_class = None
     _attr_name = f"{NAME} Device Health"
     _attr_icon = ICON_HEALTH
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
     def native_value(self):

--- a/custom_components/sutro/sensor.py
+++ b/custom_components/sutro/sensor.py
@@ -10,7 +10,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-
 from .const import ATTRIBUTION
 from .const import DOMAIN
 from .const import ICON_ACIDITY

--- a/custom_components/sutro/sensor.py
+++ b/custom_components/sutro/sensor.py
@@ -15,8 +15,8 @@ from .const import ATTRIBUTION
 from .const import DOMAIN
 from .const import ICON_ACIDITY
 from .const import ICON_ALKALINITY
-from .const import ICON_CHARGES
 from .const import ICON_BROMINE
+from .const import ICON_CHARGES
 from .const import ICON_CHLORINE
 from .const import ICON_HEALTH
 from .const import NAME


### PR DESCRIPTION
This PR adds additional sensors to the Sutro Device Integration.

It adds the following sensors
* Bromine ppm
* Device Health

It also adds the following Binary Sensors
* Device Core Status
* Device Lid Open
* Device Online
* Device Taking Readings
* Hub Online

As well It adds the reading time to the device sensors that only get periodically read (chlorine, bromine, alkalinity, and ph)

Signed-off-by: Brian Towles <brian@towles.com>