### PR TITLE
Adds support for using the login credentials to get the API token.

### DIFF
--- a/custom_components/sutro/__init__.py
+++ b/custom_components/sutro/__init__.py
@@ -11,14 +11,14 @@ import logging
 from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .api import SutroApiClient
-from .const import CONF_TOKEN
+from .api import SutroDataApiClient
 from .const import DOMAIN
 from .const import PLATFORMS
 from .const import STARTUP_MESSAGE
@@ -38,7 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if token:
         session = async_get_clientsession(hass)
-        client = SutroApiClient(token, session)
+        client = SutroDataApiClient(token, session)
 
         coordinator = SutroDataUpdateCoordinator(hass, client)
         await coordinator.async_refresh()
@@ -66,7 +66,7 @@ class SutroDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(
         self,
         hass: HomeAssistant,
-        client: SutroApiClient,
+        client: SutroDataApiClient,
     ) -> None:
         """Initialize."""
         self.api = client

--- a/custom_components/sutro/api.py
+++ b/custom_components/sutro/api.py
@@ -70,7 +70,7 @@ class SutroApiClient:
 class SutroLoginApiClient(SutroApiClient):
     """Sutro API Client class to handle login."""
 
-    async def async_get_login(self, username, password) -> dict | None:
+    async def async_get_login(self, email, password) -> dict | None:
         """Login with the Sutro Credentials and get the Token."""
 
         query = """
@@ -88,7 +88,7 @@ class SutroLoginApiClient(SutroApiClient):
         payload = {
             "query": query,
             "variables": {
-                "email": username,
+                "email": email,
                 "password": password,
             },
         }

--- a/custom_components/sutro/translations/en.json
+++ b/custom_components/sutro/translations/en.json
@@ -4,12 +4,17 @@
       "user": {
         "description": "If you need help with the configuration have a look here: https://github.com/ydogandjiev/hass-sutro",
         "data": {
-          "token": "Token"
+          "token": "Token",
+          "password": "Password",
+          "email": "Email"
         }
       }
     },
     "error": {
-      "auth": "Token is invalid or expired."
+      "auth": "Login failed.",
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     }
   },
   "options": {


### PR DESCRIPTION
This PR changes the config flow to allow user to enter their Sutro login credentials and the integration will get the API key needed by making a GraphQL login mutation call.  

This keeps the current storage format of the Token only so there is no need for any upgrade code to be run for existing users.

Documentation changes will need to be made to remove the information on how to get the API key if this is accepted.

Fixes #23 

Signed-off-by: Brian Towles <brian@towles.com>