### PR TITLE
Allow integration name to be pulled from pool type

### DIFF
--- a/custom_components/sutro/api.py
+++ b/custom_components/sutro/api.py
@@ -75,6 +75,9 @@ class SutroLoginApiClient(SutroApiClient):
                         firstName
                         lastName
                         email
+                        pool {
+                            type
+                        }
                     }
                     token
                 }

--- a/custom_components/sutro/config_flow.py
+++ b/custom_components/sutro/config_flow.py
@@ -41,7 +41,7 @@ class SutroFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if data and "login" in data and data["login"] is not None:
                 stored_data[CONF_TOKEN] = data["login"]["token"]
                 return self.async_create_entry(
-                    title=f"{data['login']['user']['firstName']}'s Pool/Spa",
+                    title=f"{data['login']['user']['firstName']}'s {data['login']['user']['pool']['type'].title()}",
                     data=stored_data,
                 )
 

--- a/custom_components/sutro/config_flow.py
+++ b/custom_components/sutro/config_flow.py
@@ -42,8 +42,8 @@ class SutroFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 stored_data[CONF_TOKEN] = data["login"]["token"]
 
                 pool_type = "Pool/Spa"
-                if data['login']['user']['pool']['type']:
-                    pool_type = data['login']['user']['pool']['type'].title()
+                if data["login"]["user"]["pool"]["type"]:
+                    pool_type = data["login"]["user"]["pool"]["type"].title()
                 return self.async_create_entry(
                     title=f"{data['login']['user']['firstName']}'s {pool_type}",
                     data=stored_data,

--- a/custom_components/sutro/config_flow.py
+++ b/custom_components/sutro/config_flow.py
@@ -40,8 +40,12 @@ class SutroFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             stored_data = {}
             if data and "login" in data and data["login"] is not None:
                 stored_data[CONF_TOKEN] = data["login"]["token"]
+
+                pool_type = "Pool/Spa"
+                if data['login']['user']['pool']['type']:
+                    pool_type = data['login']['user']['pool']['type'].title()
                 return self.async_create_entry(
-                    title=f"{data['login']['user']['firstName']}'s {data['login']['user']['pool']['type'].title()}",
+                    title=f"{data['login']['user']['firstName']}'s {pool_type}",
                     data=stored_data,
                 )
 


### PR DESCRIPTION
This PR get the pool type from the graphql login call and sets the integration name to the defined type.

For example if its a Pool it sets it to **\<First Name\>'s Pool"** and if its a Spa sets it to **\<First Name\>'s Spa"**