### PR TITLE
Fix "None" naming issue for binary sensors

### DIFF
--- a/custom_components/sutro/binary_sensor.py
+++ b/custom_components/sutro/binary_sensor.py
@@ -1,6 +1,5 @@
 """Binary Sensor platform for Sutro."""
 import logging
-import os
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.binary_sensor import DEVICE_CLASS_CONNECTIVITY

--- a/custom_components/sutro/binary_sensor.py
+++ b/custom_components/sutro/binary_sensor.py
@@ -10,12 +10,11 @@ from homeassistant.helpers.entity import EntityCategory
 
 from .const import DOMAIN
 from .const import ICON_DEVICE_ONLINE
+from .const import NAME
 from .entity import SutroEntity
 
 
 logger = logging.getLogger(__name__)
-
-NAME = os.environ.get("NAME")
 
 
 async def async_setup_entry(hass, entry, async_add_devices):


### PR DESCRIPTION
This fixes the naming issue for Binary Sensors that sets them to None instead of Sutro.